### PR TITLE
Refactor release tagging process to a separate workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: Build
 on:
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,22 +60,3 @@ jobs:
 
       - name: Run om tests
         run: om init --test .
-
-  create-tag:
-    needs: build
-    if: github.ref == 'refs/heads/main' && success()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create and push tag
-        run: |
-          TAG="release-$(date +'%Y%m%d')-${GITHUB_SHA::7}"
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          git tag -a "$TAG" -m "Automated release tag"
-          git push origin "$TAG"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+name: "Create Release Tag"
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Create and push tag
+        run: |
+          TAG="release-$(date +'%Y%m%d')-${GITHUB_SHA::7}"
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git tag -a "$TAG" -m "Automated release tag"
+          git push origin "$TAG"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Move the release tagging process to a dedicated workflow triggered by the completion of the CI workflow, streamlining the tagging process.